### PR TITLE
[feat] create global PrismaModule for centralized database access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ CORS_ORIGIN="http://localhost:5173,http://localhost:3000"
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 
 # Throttler (rate limiting)
-# TTL in milliseconds (e.g., 60_000 = 1 minute)
-THROTTLER_TTL=60_000
+# TTL in milliseconds (e.g., 60000 = 1 minute)
+THROTTLER_TTL=60000
 # Number of requests allowed per TTL window
 THROTTLER_LIMIT=100

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ CORS_ORIGIN="http://localhost:5173,http://localhost:3000"
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 
 # Throttler (rate limiting)
-# TTL in milliseconds (e.g., 60000 = 1 minute)
-THROTTLER_TTL=60000
+# TTL in milliseconds (e.g., 60_000 = 1 minute)
+THROTTLER_TTL=60_000
 # Number of requests allowed per TTL window
 THROTTLER_LIMIT=100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Seed database
+        run: pnpm prisma:seed
+
       - name: Run e2e tests
         env:
           DATABASE_URL: postgresql://user:password@localhost:5432/mydatabase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
           --health-retries=5
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -46,7 +49,7 @@ jobs:
           cp .env.example .env
           echo "DATABASE_URL=postgresql://user:password@localhost:5432/mydatabase" >> .env
 
-      - name: Install deps
+      - name: Install dependencies
         run: pnpm install
 
       - name: Generate Prisma client
@@ -55,21 +58,21 @@ jobs:
       - name: Run migrations
         run: pnpm prisma:migrate deploy
 
+      - name: Seed database
+        run: pnpm prisma:seed
+
       - name: Lint
         run: pnpm lint
 
       - name: Build
         run: pnpm build
 
-      - name: Seed database
-        run: pnpm prisma:seed
-
       - name: Run e2e tests
         env:
           DATABASE_URL: postgresql://user:password@localhost:5432/mydatabase
         run: pnpm test:e2e
 
-      - name: Run commitlint on PR commits
+      - name: Run commitlint
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             pnpm dlx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,50 +1,72 @@
 name: CI
 
 on:
-    push:
-        branches: [production]
-    pull_request: {}
+  push:
+    branches: [production]
+  pull_request: {}
 
 jobs:
-    build-and-lint:
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                node: [22.17.0]
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [22.17.0]
 
-        steps:
-            - uses: actions/checkout@v4
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: mydatabase
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U user -d mydatabase"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=5
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@v4
-              with:
-                  version: 10.17.1
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: Use Node.js ${{ matrix.node }}
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ matrix.node }}
-                  cache: 'pnpm'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
 
-            - name: Set up .env file
-              run: cp .env.example .env
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
 
-            - name: Install deps
-              run: pnpm install
+      - name: Create .env file
+        run: |
+          cp .env.example .env
+          echo "DATABASE_URL=postgresql://user:password@localhost:5432/mydatabase" >> .env
 
-            - name: Generate Prisma client
-              run: pnpm prisma:generate
+      - name: Install deps
+        run: pnpm install
 
-            - name: Lint
-              run: pnpm lint
+      - name: Generate Prisma client
+        run: pnpm prisma:generate
 
-            - name: Build
-              run: pnpm build
+      - name: Run migrations
+        run: pnpm prisma:migrate deploy
 
-            - name: Run e2e tests
-              run: pnpm test:e2e
+      - name: Lint
+        run: pnpm lint
 
-            - name: Run commitlint on PR commits
-              if: github.event_name == 'pull_request'
-              run: |
-                  pnpm dlx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }}
+      - name: Build
+        run: pnpm build
+
+      - name: Run e2e tests
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/mydatabase
+        run: pnpm test:e2e
+
+      - name: Run commitlint on PR commits
+        if: github.event_name == 'pull_request'
+        run: |
+          pnpm dlx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
         run: pnpm test:e2e
 
       - name: Run commitlint on PR commits
-        if: github.event_name == 'pull_request'
         run: |
-          pnpm dlx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }}
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pnpm dlx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }}
+          else
+            pnpm dlx commitlint --from=$(git rev-list --max-parents=0 HEAD) --to=HEAD
+          fi

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,7 +1,7 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
-      'header-max-length': [2, 'always', 120],
+      'header-max-length': [2, 'always', 140],
     },
   };
   

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+      'header-max-length': [2, 'always', 120],
+    },
+  };
+  

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,0 @@
-export default {
-    extends: ['@commitlint/config-conventional'],
-};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,58 +6,72 @@ import tseslint from 'typescript-eslint';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 
 export default tseslint.config(
-    {
-      ignores: ['eslint.config.mjs', "prisma/seed.ts", 'commitlint.config.js'],
-    },
-    eslint.configs.recommended,
-    ...tseslint.configs.recommendedTypeChecked,
-    eslintPluginPrettierRecommended,
-    {
-      languageOptions: {
-        globals: {
-          ...globals.node,
-          ...globals.jest,
-        },
-        sourceType: 'commonjs',
-        parserOptions: {
-          projectService: true,
-          tsconfigRootDir: import.meta.dirname,
-        },
+  {
+    ignores: ['eslint.config.mjs', 'prisma/seed.ts', 'commitlint.config.js'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
       },
-      plugins: {
-        'simple-import-sort': simpleImportSort,
-      },
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-floating-promises': 'warn',
-        '@typescript-eslint/no-unsafe-argument': 'warn',
-
-        'simple-import-sort/imports': 'error',
-        'simple-import-sort/exports': 'error',
-
-        '@typescript-eslint/consistent-type-imports': [
-          'error',
-          {
-            prefer: 'type-imports',
-            disallowTypeAnnotations: true,
-            fixStyle: 'inline-type-imports',
-          },
-        ],
-
-        '@typescript-eslint/explicit-member-accessibility': [
-          'error',
-          {
-            accessibility: 'explicit',
-            overrides: {
-              constructors: 'no-public',
-            },
-          },
-        ],
-
-        '@typescript-eslint/no-unused-vars': [
-          'warn',
-          { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
-        ],
+      sourceType: 'commonjs',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
+    plugins: {
+      'simple-import-sort': simpleImportSort,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          disallowTypeAnnotations: true,
+          fixStyle: 'inline-type-imports',
+        },
+      ],
+
+      '@typescript-eslint/explicit-member-accessibility': [
+        'error',
+        {
+          accessibility: 'explicit',
+          overrides: {
+            constructors: 'no-public',
+          },
+        },
+      ],
+
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
+
+      'padding-line-between-statements': [
+        'error',
+        { blankLine: 'always', prev: 'import', next: '*' },
+        { blankLine: 'any', prev: 'import', next: 'import' },
+        { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
+        { blankLine: 'any', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var'] },
+        { blankLine: 'always', prev: '*', next: 'return' },
+        { blankLine: 'always', prev: '*', next: ['if', 'for', 'switch', 'try'] },
+        { blankLine: 'always', prev: ['if', 'for', 'switch', 'try'], next: '*' },
+        { blankLine: 'always', prev: 'method', next: 'method' },
+        { blankLine: 'always', prev: 'field', next: 'method' },
+        { blankLine: 'always', prev: 'method', next: 'field' },
+      ],
+    },
+  },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,29 +4,28 @@ import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import { defineConfig } from 'eslint/config';
 
-export default tseslint.config(
+export default defineConfig([
   {
     ignores: ['eslint.config.mjs', 'prisma/seed.ts', 'commitlint.config.js'],
   },
+
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   eslintPluginPrettierRecommended,
+
   {
+    files: ['src/**/*.ts', 'apps/**/*.ts', 'libs/**/*.ts'],
     languageOptions: {
-      globals: {
-        ...globals.node,
-        ...globals.jest,
-      },
+      globals: { ...globals.node, ...globals.jest },
       sourceType: 'commonjs',
       parserOptions: {
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
     },
-    plugins: {
-      'simple-import-sort': simpleImportSort,
-    },
+    plugins: { 'simple-import-sort': simpleImportSort },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
@@ -34,27 +33,15 @@ export default tseslint.config(
 
       '@typescript-eslint/consistent-type-imports': [
         'error',
-        {
-          prefer: 'type-imports',
-          disallowTypeAnnotations: true,
-          fixStyle: 'inline-type-imports',
-        },
+        { prefer: 'type-imports', disallowTypeAnnotations: true, fixStyle: 'inline-type-imports' },
       ],
 
       '@typescript-eslint/explicit-member-accessibility': [
         'error',
-        {
-          accessibility: 'explicit',
-          overrides: {
-            constructors: 'no-public',
-          },
-        },
+        { accessibility: 'explicit', overrides: { constructors: 'no-public' } },
       ],
 
-      '@typescript-eslint/no-unused-vars': [
-        'warn',
-        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
-      ],
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
 
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
@@ -68,10 +55,28 @@ export default tseslint.config(
         { blankLine: 'always', prev: '*', next: 'return' },
         { blankLine: 'always', prev: '*', next: ['if', 'for', 'switch', 'try'] },
         { blankLine: 'always', prev: ['if', 'for', 'switch', 'try'], next: '*' },
-        { blankLine: 'always', prev: 'method', next: 'method' },
-        { blankLine: 'always', prev: 'field', next: 'method' },
-        { blankLine: 'always', prev: 'method', next: 'field' },
       ],
+
+      'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
     },
   },
-);
+
+  {
+    ...tseslint.configs.disableTypeChecked,
+    files: ['test/**/*.ts', '**/*.spec.ts', '**/*.e2e-spec.ts'],
+  },
+
+  {
+    files: ['test/**/*.ts', '**/*.spec.ts', '**/*.e2e-spec.ts'],
+    languageOptions: {
+      globals: { ...globals.node, ...globals.jest },
+    },
+    rules: {
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+    },
+  },
+]);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from 'generated/prisma';
+import { PrismaClient } from '@prisma/client';
 import { faker } from '@faker-js/faker';
 
 const prisma = new PrismaClient();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { validate } from './config/env.validation';
 import { ExampleModule } from './example/example.module';
+import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
     imports: [
@@ -26,6 +27,7 @@ import { ExampleModule } from './example/example.module';
                 ],
             }),
         }),
+        PrismaModule,
         ExampleModule,
     ],
     providers: [

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -30,6 +30,14 @@ export class EnvironmentVariables {
     /** Comma-separated list of allowed CORS origins. */
     @IsString()
     public CORS_ORIGIN: string;
+
+    /** Throttler TTL (e.g., 60_000). */
+    @IsNumber()
+    public THROTTLER_TTL: number;
+
+    /** Throttler limit (e.g., 100). */
+    @IsNumber()
+    public THROTTLER_LIMIT: number;
 }
 
 /**

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -20,23 +20,25 @@ export class EnvironmentVariables {
     public NODE_ENV: Env;
 
     /** Application port number (e.g., 3000). */
-    @IsNumber()
+    @IsNumber({}, { message: 'PORT must be a numeric value' })
     public PORT: number;
 
     /** PostgreSQL connection string. */
-    @Matches(/^postgres(ql)?:\/\/.+$/)
+    @Matches(/^postgres(ql)?:\/\/.+$/, {
+        message: 'DATABASE_URL must be a valid PostgreSQL connection string',
+    })
     public DATABASE_URL: string;
 
     /** Comma-separated list of allowed CORS origins. */
     @IsString()
     public CORS_ORIGIN: string;
 
-    /** Throttler TTL (e.g., 60_000). */
-    @IsNumber()
+    /** Throttler TTL (milliseconds, e.g. 60000). */
+    @IsNumber({}, { message: 'THROTTLER_TTL must be a numeric value (milliseconds)' })
     public THROTTLER_TTL: number;
 
-    /** Throttler limit (e.g., 100). */
-    @IsNumber()
+    /** Throttler request limit per TTL window (e.g. 100). */
+    @IsNumber({}, { message: 'THROTTLER_LIMIT must be a numeric value' })
     public THROTTLER_LIMIT: number;
 }
 

--- a/src/example/dto/responses/example-response.dto.ts
+++ b/src/example/dto/responses/example-response.dto.ts
@@ -1,9 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { User } from 'generated/prisma';
+
+export class ExampleResponseUserDto implements User {
+    @ApiProperty({ example: 1, description: 'User ID' })
+    public id: number;
+
+    @ApiProperty({ example: 'John Doe', description: 'User name' })
+    public name: string | null;
+
+    @ApiProperty({ example: 'john.doe@example.com', description: 'User email' })
+    public email: string;
+}
 
 export class ExampleResponseDto {
-    @ApiProperty({ example: true, description: 'Indicates whether the response was successful' })
-    public ok: boolean;
-
-    @ApiProperty({ example: 'Hello from rs-nest-template', description: 'Response message' })
-    public msg: string;
+    @ApiProperty({ example: [], description: 'Users', type: [ExampleResponseUserDto] })
+    public users: ExampleResponseUserDto[];
 }

--- a/src/example/dto/responses/example-response.dto.ts
+++ b/src/example/dto/responses/example-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { User } from 'generated/prisma';
+import { User } from '@prisma/client';
 
 export class ExampleResponseUserDto implements User {
     @ApiProperty({ example: 1, description: 'User ID' })

--- a/src/example/example.controller.ts
+++ b/src/example/example.controller.ts
@@ -16,7 +16,7 @@ export class ExampleController {
         description: 'Successful response',
         type: ExampleResponseDto,
     })
-    public getHello(): ExampleResponseDto {
+    public getHello(): Promise<ExampleResponseDto> {
         return this.exampleUseCase.execute();
     }
 }

--- a/src/example/types/outputs/example-output.type.ts
+++ b/src/example/types/outputs/example-output.type.ts
@@ -1,4 +1,5 @@
+import { type User } from 'generated/prisma';
+
 export interface ExampleOutputType {
-    ok: boolean;
-    msg: string;
+    users: User[];
 }

--- a/src/example/types/outputs/example-output.type.ts
+++ b/src/example/types/outputs/example-output.type.ts
@@ -1,4 +1,4 @@
-import { type User } from 'generated/prisma';
+import { type User } from '@prisma/client';
 
 export interface ExampleOutputType {
     users: User[];

--- a/src/example/use-cases/example.use-case.ts
+++ b/src/example/use-cases/example.use-case.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
-import { PrismaService } from '../../prisma/prisma.service';
+import { PrismaService } from '@/prisma/prisma.service';
+
 import { ExampleOutputType } from '../types';
 
 @Injectable()

--- a/src/example/use-cases/example.use-case.ts
+++ b/src/example/use-cases/example.use-case.ts
@@ -9,6 +9,7 @@ export class ExampleUseCase {
 
     public async execute(): Promise<ExampleOutputType> {
         const users = await this.prisma.user.findMany();
+
         return { users };
     }
 }

--- a/src/example/use-cases/example.use-case.ts
+++ b/src/example/use-cases/example.use-case.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@nestjs/common';
 
+import { PrismaService } from '../../prisma/prisma.service';
 import { ExampleOutputType } from '../types';
 
 @Injectable()
 export class ExampleUseCase {
-    public execute(): ExampleOutputType {
-        return { ok: true, msg: 'Hello from rs-nest-template' };
+    constructor(private readonly prisma: PrismaService) {}
+
+    public async execute(): Promise<ExampleOutputType> {
+        const users = await this.prisma.user.findMany();
+        return { users };
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ async function bootstrap() {
         .build();
 
     const document = SwaggerModule.createDocument(app, config);
+
     SwaggerModule.setup('api/docs', app, document);
 
     await app.listen(port);

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+    exports: [PrismaService],
+    providers: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -9,6 +9,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
         await this.$disconnect();
         this.logger.log('Disconnected from database');
     }
+
     public async onModuleInit(): Promise<void> {
         await this.$connect();
         this.logger.log('Connected to database');

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from 'generated/prisma';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+    private readonly logger = new Logger(PrismaService.name);
+
+    public async onModuleDestroy(): Promise<void> {
+        await this.$disconnect();
+        this.logger.log('Disconnected from database');
+    }
+    public async onModuleInit(): Promise<void> {
+        await this.$connect();
+        this.logger.log('Connected to database');
+    }
+}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from 'generated/prisma';
+import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {

--- a/test/example.e2e-spec.ts
+++ b/test/example.e2e-spec.ts
@@ -1,32 +1,48 @@
-import { type INestApplication } from '@nestjs/common';
-import { Test, type TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { type App } from 'supertest/types';
+import type { App } from 'supertest/types';
 
 import { AppModule } from '../src/app.module';
 
 describe('ExampleController (e2e)', () => {
-    let app: INestApplication<App>;
+  let app: INestApplication<App>;
 
-    beforeAll(async () => {
-        const moduleFixture: TestingModule = await Test.createTestingModule({
-            imports: [AppModule],
-        }).compile();
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
 
-        app = moduleFixture.createNestApplication();
-        await app.init();
-    });
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
 
-    afterAll(async () => {
-        await app.close();
-    });
+  afterAll(async () => {
+    await app.close();
+  });
 
-    it('/example (GET) → should return a greeting message', async () => {
-        const res = await request(app.getHttpServer()).get('/example').expect(200);
+  it('/example (GET) → should return users', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/example')
+      .expect(200);
 
-        expect(res.body).toEqual({
-            ok: true,
-            msg: 'Hello from rs-nest-template',
-        });
-    });
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        users: expect.any(Array),
+      }),
+    );
+
+    const { users } = res.body;
+    expect(Array.isArray(users)).toBe(true);
+    expect(users).toHaveLength(11);
+
+    const user = users[0];
+    expect(user).toEqual(
+      expect.objectContaining({
+        id: expect.any(Number),
+        name: expect.anything(),
+        email: expect.any(String),
+      }),
+    );
+  });
 });

--- a/test/example.e2e-spec.ts
+++ b/test/example.e2e-spec.ts
@@ -1,48 +1,48 @@
-import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import { type INestApplication } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import type { App } from 'supertest/types';
 
 import { AppModule } from '../src/app.module';
 
 describe('ExampleController (e2e)', () => {
-  let app: INestApplication<App>;
+    let app: INestApplication<App>;
 
-  beforeAll(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+    beforeAll(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
 
-    app = moduleFixture.createNestApplication();
-    await app.init();
-  });
+        app = moduleFixture.createNestApplication();
+        await app.init();
+    });
 
-  afterAll(async () => {
-    await app.close();
-  });
+    afterAll(async () => {
+        await app.close();
+    });
 
-  it('/example (GET) → should return users', async () => {
-    const res = await request(app.getHttpServer())
-      .get('/example')
-      .expect(200);
+    it('/example (GET) → should return users', async () => {
+        const res = await request(app.getHttpServer()).get('/example').expect(200);
 
-    expect(res.body).toEqual(
-      expect.objectContaining({
-        users: expect.any(Array),
-      }),
-    );
+        expect(res.body).toEqual(
+            expect.objectContaining({
+                users: expect.any(Array),
+            }),
+        );
 
-    const { users } = res.body;
-    expect(Array.isArray(users)).toBe(true);
-    expect(users).toHaveLength(11);
+        const { users } = res.body;
 
-    const user = users[0];
-    expect(user).toEqual(
-      expect.objectContaining({
-        id: expect.any(Number),
-        name: expect.anything(),
-        email: expect.any(String),
-      }),
-    );
-  });
+        expect(Array.isArray(users)).toBe(true);
+        expect(users).toHaveLength(11);
+
+        const user = users[0];
+
+        expect(user).toEqual(
+            expect.objectContaining({
+                id: expect.any(Number),
+                name: expect.anything(),
+                email: expect.any(String),
+            }),
+        );
+    });
 });

--- a/test/example.e2e-spec.ts
+++ b/test/example.e2e-spec.ts
@@ -3,7 +3,7 @@ import { Test, type TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import type { App } from 'supertest/types';
 
-import { AppModule } from '../src/app.module';
+import { AppModule } from '@/app.module';
 
 describe('ExampleController (e2e)', () => {
     let app: INestApplication<App>;

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,14 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/src/$1",
+    "^generated/(.*)$": "<rootDir>/generated/$1",
+    "^@test/(.*)$": "<rootDir>/test/$1"
   }
 }

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -8,7 +8,6 @@
   },
   "moduleNameMapper": {
     "^@/(.*)$": "<rootDir>/src/$1",
-    "^generated/(.*)$": "<rootDir>/generated/$1",
     "^@test/(.*)$": "<rootDir>/test/$1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "baseUrl": ".",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,12 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+
+    "paths": {
+      "generated/*": ["./generated/*"],
+      "@/*": ["./src/*"],
+      "@test/*": ["./test/*"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
     "noFallthroughCasesInSwitch": false,
 
     "paths": {
-      "generated/*": ["./generated/*"],
       "@/*": ["./src/*"],
       "@test/*": ["./test/*"]
     }


### PR DESCRIPTION
## Type
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] chore

## Summary
Implemented a new global `PrismaModule` to provide centralized database access across all application services.

Key changes:
- Added `prisma.service.ts` extending `PrismaClient` with `onModuleInit` and `onModuleDestroy` lifecycle methods.
- Added `prisma.module.ts` marked as `@Global()` and exporting `PrismaService`.
- Integrated `PrismaModule` into `AppModule`.
- Verified connection handling (open on startup, close on shutdown).
- Tested service injection and database queries using `PrismaService`.

## Related Issues
Closes #2 (Create Prisma module)

## Checklist
- [x] Code formatted with Prettier
- [x] Linter passes without errors
- [x] Tests added or updated (if necessary)
- [x] Documentation updated (README / Swagger)

## Screenshots / Examples
N/A — functionality verified via runtime and service injection tests.
